### PR TITLE
feat(admin): add sidebar link to personal profile

### DIFF
--- a/jdav_web/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-15 23:05+0200\n"
+"POT-Creation-Date: 2025-12-06 00:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,6 +134,18 @@ msgstr ""
 #: logindata/views.py
 msgid "You entered a wrong password."
 msgstr "Das eingegebene Passwort ist falsch."
+
+#: templates/admin/base.html
+msgid "My Profile"
+msgstr "Mein Profil"
+
+#: templates/admin/base.html
+msgid "Change password"
+msgstr "Passwort ändern"
+
+#: templates/admin/base.html
+msgid "Log out"
+msgstr "Abmelden"
 
 #: templates/admin/delete_confirmation.html
 #, python-format

--- a/jdav_web/templates/admin/base.html
+++ b/jdav_web/templates/admin/base.html
@@ -75,6 +75,9 @@ django.gettext = window.gettext
                         <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
                     {% endif %}
                 {% endif %}
+                {% if user.member %}
+                <a href="{% url 'admin:members_member_change' user.member.pk %}">{% trans 'My Profile' %}</a> /
+                {% endif %}
                 {% if user.has_usable_password %}
                 <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
                 {% endif %}
@@ -198,6 +201,14 @@ django.gettext = window.gettext
                         </a>
                     {% endif %}
                     {% if user.is_active and user.is_staff %}
+                        {% if user.member %}
+                        <a href="{% url 'admin:members_member_change' user.member.pk %}" class="sidebar-link icon">
+                            <span class="sidebar-link-label">
+                                <span class="sidebar-link-icon icon-user"></span>
+                                {% trans 'My Profile' %}
+                            </span>
+                        </a>
+                        {% endif %}
                         {% if user.has_usable_password %}
                         <a href="{% url 'admin:password_change' %}" class="sidebar-link icon">
                             <span class="sidebar-link-label">


### PR DESCRIPTION
this pr adds an additional item in the admin page sidebar that links to the active users personal profile
Only works if login data is connected to a member object

closes #38 