### PR TITLE
fix(members): validate `birth_date` in `request_echo_view`

### DIFF
--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -479,6 +479,13 @@ class MemberAdmin(CommonAdminMixin, admin.ModelAdmin):
             messages.warning(
                 request, _("%(name)s does not receive the newsletter.") % {"name": member.name}
             )
+        elif not member.birth_date:
+            messages.error(
+                request,
+                _(
+                    "Member {name} doesn't have a birthdate set, which is mandatory for echo requests"
+                ).format(name=member.name),
+            )
         else:
             member.request_echo()
             messages.success(

--- a/jdav_web/members/tests/basic.py
+++ b/jdav_web/members/tests/basic.py
@@ -993,6 +993,21 @@ class MemberAdminTestCase(AdminTestCase):
         response = c.get(url, follow=True)
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
+    def test_request_echo_view_fail_on_missing_birthdate(self):
+        self.peter.birth_date = None
+        self.peter.save()
+
+        c = self._login("superuser")
+        url = reverse("admin:members_member_requestecho", args=(self.peter.pk,))
+        response = c.get(url, follow=True)
+
+        self.assertContains(
+            response,
+            _(
+                "Member {name} doesn't have a birthdate set, which is mandatory for echo requests"
+            ).format(name=self.peter.name),
+        )
+
     def test_activity_score(self):
         # manually set activity score
         for i in range(5):


### PR DESCRIPTION
Add `birth_date` validation to `request_echo_view` to prevent internal server errors when requesting echo from members without a birth date.

This applies the same validation that already exists in the `request_echo` admin action.

Closes #67