### PR TITLE
feat(ci): show uncovered lines in coverage report

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -120,6 +120,10 @@ jobs:
 
       - name: Check coverage
         run: |
+          echo "=== Coverage Report ==="
+          cat docker/test/htmlcov/coverage_report.txt
+          echo ""
+          echo "=== Coverage Check ==="
           COVERAGE=$(python3 -c "import json; data=json.load(open('docker/test/htmlcov/coverage.json')); print(data['totals']['percent_covered'])")
           echo "Coverage: ${COVERAGE}%"
           if (( $(echo "$COVERAGE < 100" | bc -l) )); then

--- a/docker/test/entrypoint-master.sh
+++ b/docker/test/entrypoint-master.sh
@@ -46,3 +46,4 @@ fi
 coverage html --show-contexts
 coverage json -o htmlcov/coverage.json
 coverage report
+coverage report --show-missing > htmlcov/coverage_report.txt


### PR DESCRIPTION
Update the GitHub workflow coverage check to display all uncovered lines before verifying 100% coverage requirement.

Changes:
- Generate coverage report with `--show-missing` flag and save to file
- Display full coverage report in GitHub Actions output
- Maintain existing 100% coverage requirement

This makes it easier to identify which lines need tests when coverage drops below 100%.