### PR TITLE
docs(contributing): update with PR guidelines

### DIFF
--- a/docs/source/development_manual/contributing.rst
+++ b/docs/source/development_manual/contributing.rst
@@ -49,7 +49,7 @@ Pull request descriptions should:
 
 - Be kept short and concise
 - Avoid repetitions
-- Use no formatting beyond backticks for inline code (````code````) or code blocks
+- Use no formatting beyond single backticks for inline code (```code```) or code blocks
 - Explain what changes were made and why
 - Not repeat information already in the title
 - Not include "Generated with Claude" or similar lines


### PR DESCRIPTION
Replace the workflow section with a new pull request guidelines section.

The new section explains:
- All PRs are squash merged, description becomes commit message
- Title format using conventional commits
- Description format: short, no repetitions, backticks only for code
- Includes example PR description