### PR TITLE
fix(ci): fix permissions for PRs from forks

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   pull_request_target:
 
 concurrency:
@@ -18,6 +19,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Run on push to main, internal PRs (pull_request), or fork PRs (pull_request_target)
+    # This prevents duplicate runs while allowing workflow testing in internal PRs
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
Change trigger from `pull_request` to `pull_request_target` to ensure CI runs with the correct permissions for PRs from forks.