### PR TITLE
feat(members/admin): add excursion overview for member

### DIFF
--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -19,6 +19,7 @@ from django.db.models import Case
 from django.db.models import ExpressionWrapper
 from django.db.models import F
 from django.db.models import IntegerField
+from django.db.models import Q
 from django.db.models import TextField
 from django.db.models import When
 from django.forms import Textarea
@@ -341,7 +342,18 @@ class MemberAdmin(CommonAdminMixin, admin.ModelAdmin):
             _("Contact information"),
             {"fields": ["street", "plz", "town", "address_extra", "country", "iban"]},
         ),
-        (_("Skills"), {"fields": ["swimming_badge", "climbing_badge", "alpine_experience"]}),
+        (
+            _("Skills"),
+            {
+                "classes": ["show-excursions-link"],
+                "fields": [
+                    "swimming_badge",
+                    "climbing_badge",
+                    "alpine_experience",
+                    "show_excursions_link",
+                ],
+            },
+        ),
         (
             _("Others"),
             {
@@ -381,7 +393,7 @@ class MemberAdmin(CommonAdminMixin, admin.ModelAdmin):
     search_fields = ("prename", "lastname", "email")
     list_filter = ("echoed", "group")
     list_display_links = None
-    readonly_fields = ["echoed", "good_conduct_certificate_valid"]
+    readonly_fields = ["echoed", "good_conduct_certificate_valid", "show_excursions_link"]
     inlines = [
         EmergencyContactInline,
         MemberDocumentInline,
@@ -473,6 +485,13 @@ class MemberAdmin(CommonAdminMixin, admin.ModelAdmin):
         )
 
     send_mail_to.short_description = _("Compose new mail to selected members")
+
+    def show_excursions_link(self, obj):
+        url = reverse("admin:members_freizeit_changelist") + f"?has_participant={obj.pk}"
+        text = _("Link to excursions")
+        return format_html(f"<a href='{url}'>{text}</a>")
+
+    show_excursions_link.short_description = _("Participated in excursions")
 
     def create_object_from(self, request, queryset):
         """
@@ -1830,13 +1849,31 @@ def decorate_download(fun):
     return aux
 
 
+class ParticipantFilter(admin.SimpleListFilter):
+    """
+    List filter on excursions: Returns excursions that the given member participated in.
+    """
+
+    title = _("Has participant")
+    parameter_name = "has_participant"
+
+    def lookups(self, request, model_admin):
+        return [(m.pk, m.name) for m in Member.objects.all()]
+
+    def queryset(self, request, queryset):
+        pk = self.value()
+        if not pk:
+            return queryset
+        return queryset.filter(Q(membersonlist__member__pk=pk) | Q(jugendleiter__pk=pk)).distinct()
+
+
 class FreizeitAdmin(CommonAdminMixin, nested_admin.NestedModelAdmin):
     # inlines = [MemberOnListInline, LJPOnListInline, StatementOnListInline]
     form = FreizeitAdminForm
     list_display = ["__str__", "date", "place", "approved"]
     search_fields = ("name",)
     ordering = ("-date",)
-    list_filter = ["groups", "approved"]
+    list_filter = [ParticipantFilter, "groups", "approved"]
     view_on_site = False
     fieldsets = (
         (

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-17 18:03+0100\n"
+"POT-Creation-Date: 2026-01-17 19:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,6 +107,12 @@ msgstr "Organisatorisches"
 
 msgid "Compose new mail to selected members"
 msgstr "Neue Nachricht an ausgewählte Teilnehmer*innen verfassen"
+
+msgid "Link to excursions"
+msgstr "Link zu Ausfahrtteilnahmen"
+
+msgid "Participated in excursions"
+msgstr "Ausfahrtteilnahmen"
 
 #, python-format
 msgid "Successfully added %(count)s member(s) to %(model)s '%(obj)s'."
@@ -431,6 +437,9 @@ msgid ""
 msgstr ""
 "Diese Ausfahrt hat keinen Seminarbericht. Bitte füge einen hinzu und "
 "versuche es erneut."
+
+msgid "Has participant"
+msgstr "Hat Teilnehmer*in"
 
 msgid ""
 "General information on your excursion. These are partly relevant for the "


### PR DESCRIPTION
Add a filter to the excursion admin to filter by participations of a given member. We add a link to the filtered overview from the skills tab of every member.

Closes #46