### PR TITLE
chore(ci): add log message and change parameters for test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,9 @@ endif
 else
 	# Show output from all containers
 ifeq ($(keepdb), true)
-	cd docker/test; DJANGO_TEST_KEEPDB=1 DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up --abort-on-container-exit
+	cd docker/test; DJANGO_TEST_KEEPDB=1 DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up --exit-code-from master
 else
-	cd docker/test; DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up --abort-on-container-exit
+	cd docker/test; DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up --exit-code-from master
 endif
 endif
 	echo "Generated coverage report. To read it, point your browser to:\n\nfile://$$(pwd)/docker/test/htmlcov/index.html"

--- a/docker/test/entrypoint-master.sh
+++ b/docker/test/entrypoint-master.sh
@@ -50,3 +50,5 @@ coverage html --show-contexts
 coverage json -o htmlcov/coverage.json
 coverage report --show-missing
 coverage report --show-missing > htmlcov/coverage_report.txt
+
+echo "Saved coverage report in htmlcov/coverage_report.txt. Exiting."


### PR DESCRIPTION
We replace `--abort-on-container-exit` by `--exit-code-from master`.