### PR TITLE
chore: less output in `make test quiet=true`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,29 +56,38 @@ else
 endif
 
 build-test:
+ifeq ($(quiet), true)
+	@cd docker/test; docker compose build > /dev/null 2>&1
+else
 	cd docker/test; docker compose build
+endif
 
 test-only:
+ifeq ($(quiet), true)
+	@mkdir -p docker/test/htmlcov
+	@chmod 777 docker/test/htmlcov
+ifeq ($(keepdb), true)
+	@cd docker/test; DJANGO_TEST_KEEPDB=1 DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up -d > /dev/null 2>&1 \
+	  || { echo "Container setup failed."; exit 1; }
+else
+	@cd docker/test; DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up -d > /dev/null 2>&1 \
+	  || { echo "Container setup failed."; exit 1; }
+endif
+	@cd docker/test; docker compose wait master > /dev/null 2>&1 || true; \
+	  python3 parse_output.py htmlcov; _EXIT=$$?; \
+	  docker compose down > /dev/null 2>&1; \
+	  exit $$_EXIT
+else
 	mkdir -p docker/test/htmlcov
 	chmod 777 docker/test/htmlcov
-ifeq ($(quiet), true)
-	# Start services in detached mode and show only master container output
-ifeq ($(keepdb), true)
-	cd docker/test; DJANGO_TEST_KEEPDB=1 DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up -d
-else
-	cd docker/test; DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up -d
-endif
-	cd docker/test; docker compose logs -f master
-	cd docker/test; docker compose down
-else
 	# Show output from all containers
 ifeq ($(keepdb), true)
 	cd docker/test; DJANGO_TEST_KEEPDB=1 DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up --exit-code-from master
 else
 	cd docker/test; DJANGO_TEST_VERBOSITY=$(or $(verbosity),2) docker compose up --exit-code-from master
 endif
-endif
 	echo "Generated coverage report. To read it, point your browser to:\n\nfile://$$(pwd)/docker/test/htmlcov/index.html"
+endif
 
 # Only execute the test target if it's not being called via 'make dev test'
 ifneq (dev,$(firstword $(MAKECMDGOALS)))

--- a/docker/test/entrypoint-master.sh
+++ b/docker/test/entrypoint-master.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+HTMLCOV_DIR=/app/jdav_web/htmlcov
+
 mysql_ready() {
 cd /app/jdav_web
 python << END
@@ -41,14 +43,25 @@ cd jdav_web
 # Default verbosity to 2 if not set
 VERBOSITY=${DJANGO_TEST_VERBOSITY:-2}
 
+set +o errexit
+
 if [[ "$DJANGO_TEST_KEEPDB" == 1 ]]; then
-    coverage run manage.py test startpage finance members contrib logindata mailer material ludwigsburgalpin test_data jdav_web -v $VERBOSITY --noinput --keepdb
+    coverage run manage.py test startpage finance members contrib logindata mailer material ludwigsburgalpin test_data jdav_web -v $VERBOSITY --noinput --keepdb 2>&1 | tee "$HTMLCOV_DIR/test_output.txt"
 else
-    coverage run manage.py test startpage finance members contrib logindata mailer material ludwigsburgalpin test_data jdav_web -v $VERBOSITY --noinput
+    coverage run manage.py test startpage finance members contrib logindata mailer material ludwigsburgalpin test_data jdav_web -v $VERBOSITY --noinput 2>&1 | tee "$HTMLCOV_DIR/test_output.txt"
 fi
+TEST_EXIT_CODE=${PIPESTATUS[0]}
+
+set -o errexit
+
 coverage html --show-contexts
 coverage json -o htmlcov/coverage.json
 coverage report --show-missing
 coverage report --show-missing > htmlcov/coverage_report.txt
 
+echo "$TEST_EXIT_CODE" > "$HTMLCOV_DIR/test_exit_code.txt"
+echo "ok" > "$HTMLCOV_DIR/run_status.txt"
+
 echo "Saved coverage report in htmlcov/coverage_report.txt. Exiting."
+
+exit $TEST_EXIT_CODE

--- a/docker/test/parse_output.py
+++ b/docker/test/parse_output.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Post-process test container output for quiet mode reporting."""
+
+import os
+import re
+import sys
+
+
+def main():
+    htmlcov_dir = sys.argv[1] if len(sys.argv) > 1 else "htmlcov"
+
+    status_file = os.path.join(htmlcov_dir, "run_status.txt")
+    if not os.path.exists(status_file):
+        print("Container setup failed or was aborted.")
+        sys.exit(1)
+
+    with open(status_file) as f:
+        if f.read().strip() != "ok":
+            print("Container setup failed or was aborted.")
+            sys.exit(1)
+
+    exit_code_file = os.path.join(htmlcov_dir, "test_exit_code.txt")
+    with open(exit_code_file) as f:
+        test_failed = int(f.read().strip()) != 0
+
+    test_output_file = os.path.join(htmlcov_dir, "test_output.txt")
+    if test_failed:
+        blocks = extract_failure_blocks(test_output_file)
+        print("The following tests failed:")
+        print()
+        if blocks:
+            print("\n".join(blocks))
+        else:
+            with open(test_output_file) as f:
+                print(f.read())
+    else:
+        print("All tests passed.")
+
+    coverage_file = os.path.join(htmlcov_dir, "coverage_report.txt")
+    missing = parse_coverage_report(coverage_file)
+    if missing:
+        print()
+        print("The following lines are not covered by tests:")
+        print()
+        for filename, lines in missing:
+            print(f"  {filename}: {lines}")
+    else:
+        print("Coverage is at 100%.")
+
+    sys.exit(1 if (test_failed or missing) else 0)
+
+
+def extract_failure_blocks(test_output_file):
+    with open(test_output_file) as f:
+        content = f.read()
+
+    # Each failure block starts with ===...===\nFAIL: or ERROR: and ends
+    # before the next ===...=== or the ---...---\nRan summary line.
+    pattern = re.compile(
+        r"={70}\n(?:FAIL|ERROR):.*?(?=\n={70}|\n-{70}\nRan )",
+        re.DOTALL,
+    )
+    return pattern.findall(content)
+
+
+def parse_coverage_report(coverage_file):
+    if not os.path.exists(coverage_file):
+        return []
+
+    missing = []
+    with open(coverage_file) as f:
+        for line in f:
+            parts = line.split()
+            if not parts or parts[0].startswith("-") or parts[0] in ("Name", "TOTAL"):
+                continue
+            if len(parts) >= 5:
+                try:
+                    if int(parts[2]) > 0:
+                        missing.append((parts[0], " ".join(parts[4:])))
+                except ValueError:
+                    pass
+    return missing
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We suppress all docker output and only show the failing tests or uncovered lines.

Closes #247 