### PR TITLE
feat(finance): historize settings at time of submission

### DIFF
--- a/jdav_web/finance/migrations/0013_statement_settings_snapshot.py
+++ b/jdav_web/finance/migrations/0013_statement_settings_snapshot.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+from django.db import models
+
+
+def _current_statement_settings_snapshot():
+    from django.conf import settings
+    from django.utils import timezone
+
+    return {
+        "ALLOWANCE_PER_DAY": float(settings.ALLOWANCE_PER_DAY),
+        "MAX_NIGHT_COST": float(settings.MAX_NIGHT_COST),
+        "AID_PER_KM_TRAIN": float(settings.AID_PER_KM_TRAIN),
+        "AID_PER_KM_CAR": float(settings.AID_PER_KM_CAR),
+        "EXCURSION_ORG_FEE": float(settings.EXCURSION_ORG_FEE),
+        "LJP_CONTRIBUTION_PER_DAY": float(settings.LJP_CONTRIBUTION_PER_DAY),
+        "LJP_TAX": float(settings.LJP_TAX),
+        "captured_at": timezone.now().isoformat(),
+    }
+
+
+def backfill_settings_snapshot(apps, _schema_editor):
+    Statement = apps.get_model("finance", "Statement")
+    snapshot = _current_statement_settings_snapshot()
+    # use historical values of Statements state constants
+    for statement in Statement.objects.filter(status__in=[1, 2]):
+        if not statement.settings_snapshot:
+            statement.settings_snapshot = snapshot
+            statement.save(update_fields=["settings_snapshot"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("finance", "0012_statementonexcursionproxy"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="statement",
+            name="settings_snapshot",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="Financial settings captured at time of submission/confirmation.",
+                verbose_name="Settings snapshot",
+            ),
+        ),
+        migrations.RunPython(backfill_settings_snapshot, migrations.RunPython.noop),
+    ]

--- a/jdav_web/finance/models.py
+++ b/jdav_web/finance/models.py
@@ -1,4 +1,5 @@
 import re
+from decimal import Decimal
 from itertools import groupby
 
 import rules
@@ -129,6 +130,12 @@ class Statement(CommonModel):
     status = models.IntegerField(
         verbose_name=_("Status"), choices=STATUS_CHOICES, default=UNSUBMITTED
     )
+    settings_snapshot = models.JSONField(
+        verbose_name=_("Settings snapshot"),
+        default=dict,
+        blank=True,
+        help_text=_("Financial settings captured at time of submission/confirmation."),
+    )
     submitted_date = models.DateTimeField(verbose_name=_("Submitted on"), default=None, null=True)
     confirmed_date = models.DateTimeField(verbose_name=_("Paid on"), default=None, null=True)
 
@@ -186,6 +193,31 @@ class Statement(CommonModel):
     def __str__(self):
         return str(self.title)
 
+    def _get_setting(self, key: str):
+        if self.submitted and self.settings_snapshot and key in self.settings_snapshot:
+            return float(self.settings_snapshot[key])
+        return float(getattr(settings, key, 0))
+
+    def _as_decimal(self, value):
+        if isinstance(value, Decimal):
+            return value
+        return Decimal(str(value))
+
+    def _capture_settings_snapshot(self, force=False):
+        if self.settings_snapshot and not force:
+            return
+
+        self.settings_snapshot = {
+            "ALLOWANCE_PER_DAY": float(settings.ALLOWANCE_PER_DAY),
+            "MAX_NIGHT_COST": float(settings.MAX_NIGHT_COST),
+            "AID_PER_KM_TRAIN": float(settings.AID_PER_KM_TRAIN),
+            "AID_PER_KM_CAR": float(settings.AID_PER_KM_CAR),
+            "EXCURSION_ORG_FEE": float(settings.EXCURSION_ORG_FEE),
+            "LJP_CONTRIBUTION_PER_DAY": float(settings.LJP_CONTRIBUTION_PER_DAY),
+            "LJP_TAX": float(settings.LJP_TAX),
+            "captured_at": timezone.now().isoformat(),
+        }
+
     @property
     def submitted(self):
         return self.status == Statement.SUBMITTED or self.status == Statement.CONFIRMED
@@ -205,6 +237,7 @@ class Statement(CommonModel):
     status_badge.admin_order_field = "status"
 
     def submit(self, submitter=None):
+        self._capture_settings_snapshot(force=True)
         self.status = self.SUBMITTED
         self.submitted_date = timezone.now()
         self.submitted_by = submitter
@@ -347,6 +380,7 @@ class Statement(CommonModel):
         if not self.validity == Statement.VALID:
             return False
 
+        self._capture_settings_snapshot()
         self.status = self.CONFIRMED
         self.confirmed_date = timezone.now()
         self.confirmed_by = confirmer
@@ -488,9 +522,9 @@ class Statement(CommonModel):
             self.excursion.tour_approach == MUSKELKRAFT_ANREISE
             or self.excursion.tour_approach == OEFFENTLICHE_ANREISE
         ):
-            return settings.AID_PER_KM_TRAIN
+            return self._get_setting("AID_PER_KM_TRAIN")
         else:
-            return settings.AID_PER_KM_CAR
+            return self._get_setting("AID_PER_KM_CAR")
 
     @property
     def transportation_per_yl(self):
@@ -504,7 +538,7 @@ class Statement(CommonModel):
         if self.excursion is None:
             return 0
 
-        return cvt_to_decimal(self.excursion.duration * settings.ALLOWANCE_PER_DAY)
+        return cvt_to_decimal(self.excursion.duration * self._get_setting("ALLOWANCE_PER_DAY"))
 
     @property
     def allowances_paid(self):
@@ -520,7 +554,7 @@ class Statement(CommonModel):
 
     @property
     def real_night_cost(self):
-        return min(self.night_cost, settings.MAX_NIGHT_COST)
+        return min(self.night_cost, self._get_setting("MAX_NIGHT_COST"))
 
     @property
     def nights_per_yl(self):
@@ -550,7 +584,7 @@ class Statement(CommonModel):
         if self.excursion is None:
             return 0
         return cvt_to_decimal(
-            settings.EXCURSION_ORG_FEE
+            self._get_setting("EXCURSION_ORG_FEE")
             * self.excursion.duration
             * self.excursion.old_participant_count
         )
@@ -633,12 +667,12 @@ class Statement(CommonModel):
             return cvt_to_decimal(
                 min(
                     # if total costs are more than the max amount of the LJP contribution, we pay the max amount, reduced by taxes
-                    (1 - settings.LJP_TAX)
-                    * settings.LJP_CONTRIBUTION_PER_DAY
+                    (1 - self._get_setting("LJP_TAX"))
+                    * self._get_setting("LJP_CONTRIBUTION_PER_DAY")
                     * self.excursion.ljp_participant_count
                     * self.excursion.ljp_duration,
                     # if the total costs are less than the max amount, we pay up to 90% of the total costs, reduced by taxes
-                    (1 - settings.LJP_TAX)
+                    (1 - self._get_setting("LJP_TAX"))
                     * 0.9
                     * (float(self.total_bills_not_covered) + float(self.total_staff)),
                     # we never pay more than the maximum costs of the trip
@@ -684,7 +718,7 @@ class Statement(CommonModel):
                 "kilometers_traveled": self.excursion.kilometers_traveled,
                 "means_of_transport": self.excursion.get_tour_approach(),
                 "euro_per_km": self.euro_per_km,
-                "allowance_per_day": settings.ALLOWANCE_PER_DAY,
+                "allowance_per_day": self._get_setting("ALLOWANCE_PER_DAY"),
                 "allowances_paid": self.allowances_paid,
                 "nights_per_yl": self.nights_per_yl,
                 "allowance_per_yl": self.allowance_per_yl,
@@ -703,12 +737,12 @@ class Statement(CommonModel):
                 "ljp_participant_count": self.excursion.ljp_participant_count,
                 "participant_count": self.excursion.participant_count,
                 "total_seminar_days": self.excursion.total_seminar_days,
-                "ljp_tax": settings.LJP_TAX * 100,
+                "ljp_tax": self._get_setting("LJP_TAX") * 100,
                 "total_org_fee_theoretical": self.total_org_fee_theoretical,
                 "total_org_fee": self.total_org_fee,
                 "old_participant_count": self.excursion.old_participant_count,
                 "total_staff_paid": self.total_staff_paid,
-                "org_fee": cvt_to_decimal(settings.EXCURSION_ORG_FEE),
+                "org_fee": cvt_to_decimal(self._get_setting("EXCURSION_ORG_FEE")),
             }
             return dict(context, **excursion_context)
         else:

--- a/jdav_web/finance/models.py
+++ b/jdav_web/finance/models.py
@@ -198,11 +198,6 @@ class Statement(CommonModel):
             return float(self.settings_snapshot[key])
         return float(getattr(settings, key, 0))
 
-    def _as_decimal(self, value):
-        if isinstance(value, Decimal):
-            return value
-        return Decimal(str(value))
-
     def _capture_settings_snapshot(self, force=False):
         if self.settings_snapshot and not force:
             return

--- a/jdav_web/finance/models.py
+++ b/jdav_web/finance/models.py
@@ -554,7 +554,7 @@ class Statement(CommonModel):
 
     @property
     def real_night_cost(self):
-        return min(self.night_cost, self._get_setting("MAX_NIGHT_COST"))
+        return min(self.night_cost, Decimal(self._get_setting("MAX_NIGHT_COST")))
 
     @property
     def nights_per_yl(self):

--- a/jdav_web/finance/tests/migrations.py
+++ b/jdav_web/finance/tests/migrations.py
@@ -1,4 +1,5 @@
 import django.test
+from django.conf import settings
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 
@@ -70,3 +71,49 @@ class StatusMigrationTestCase(django.test.TransactionTestCase):
             CONFIRMED,
             "Statement with submitted=True, confirmed=True should have status=CONFIRMED",
         )
+
+
+class StatementSettingsSnapshotMigrationTestCase(django.test.TransactionTestCase):
+    app = "finance"
+    migrate_from = [("finance", "0012_statementonexcursionproxy")]
+    migrate_to = [("finance", "0013_statement_settings_snapshot")]
+
+    def setUp(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        self.Statement = old_apps.get_model(self.app, "Statement")
+
+        self.unsubmitted = self.Statement.objects.create(
+            short_description="Unsubmitted Statement",
+            status=0,
+        )
+        self.submitted = self.Statement.objects.create(
+            short_description="Submitted Statement",
+            status=1,
+        )
+        self.confirmed = self.Statement.objects.create(
+            short_description="Confirmed Statement",
+            status=2,
+        )
+
+    def test_settings_snapshot_backfilled_for_submitted_and_confirmed(self):
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        executor.migrate(self.migrate_to)
+
+        new_apps = executor.loader.project_state(self.migrate_to).apps
+        Statement = new_apps.get_model(self.app, "Statement")
+
+        submitted = Statement.objects.get(pk=self.submitted.pk)
+        confirmed = Statement.objects.get(pk=self.confirmed.pk)
+        unsubmitted = Statement.objects.get(pk=self.unsubmitted.pk)
+
+        self.assertIsInstance(submitted.settings_snapshot, dict)
+        self.assertIn("ALLOWANCE_PER_DAY", submitted.settings_snapshot)
+        self.assertIn("captured_at", submitted.settings_snapshot)
+        self.assertEqual(
+            confirmed.settings_snapshot["MAX_NIGHT_COST"],
+            float(settings.MAX_NIGHT_COST),
+        )
+        self.assertEqual(unsubmitted.settings_snapshot, {})

--- a/jdav_web/finance/tests/models.py
+++ b/jdav_web/finance/tests/models.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
+from django.test import override_settings
 from django.test import TestCase
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -670,6 +671,31 @@ class StatementTestCase(TestCase):
         self.assertTrue(statement.submitted)
         self.assertEqual(statement.submitted_by, self.fritz)
         self.assertIsNotNone(statement.submitted_date)
+
+    def test_submit_captures_settings_snapshot_and_uses_it_for_submitted_statements(self):
+        statement = Statement.objects.create(
+            short_description="Snapshot Statement",
+            explanation="Snapshot test",
+            night_cost=25,
+        )
+
+        with override_settings(
+            ALLOWANCE_PER_DAY=42.0,
+            MAX_NIGHT_COST=120.0,
+            AID_PER_KM_TRAIN=0.16,
+            AID_PER_KM_CAR=0.28,
+            EXCURSION_ORG_FEE=15.0,
+            LJP_CONTRIBUTION_PER_DAY=22.0,
+            LJP_TAX=0.19,
+        ):
+            statement.submit(submitter=self.fritz)
+            snapshot_value = statement.settings_snapshot["ALLOWANCE_PER_DAY"]
+
+        self.assertIsInstance(statement.settings_snapshot, dict)
+        self.assertEqual(snapshot_value, 42.0)
+
+        with override_settings(ALLOWANCE_PER_DAY=99.0):
+            self.assertEqual(statement._get_setting("ALLOWANCE_PER_DAY"), snapshot_value)
 
     def test_template_context_with_excursion(self):
         """Test statement template context when excursion is present"""


### PR DESCRIPTION
currently submitted and completed statements are displayed using live settings
of the application. When they change, already completed statements would show
the wrong sums etc. To prevent this, the current state of settings is now stored
along every statement during submission and are used for calculations instead of
live settings.

Migrations: Existing submitted and completed statements are assigned the
state of settings at the time of migration. Thus, this migration has to be run
before any settings change is made. draft statements are not affected by this
change.

fixes #249 