### PR TITLE
feat(config): add setting to disable sidebar sections by app label

### DIFF
--- a/deploy/config/settings.toml
+++ b/deploy/config/settings.toml
@@ -38,6 +38,13 @@ root_section = 'wir'
 recent_section = 'aktuelles'
 reports_section = 'berichte'
 
+[sidebar]
+# List of app labels whose admin sidebar sections should be hidden.
+# Available app labels: members, mailer, finance, logindata, django_celery_beat,
+#                       ludwigsburgalpin, material, startpage
+# disabled_apps = ["ludwigsburgalpin"]
+disabled_apps = []
+
 [django]
 deployed = true
 debug = false

--- a/jdav_web/jdav_web/settings/components/jet.py
+++ b/jdav_web/jdav_web/settings/components/jet.py
@@ -6,7 +6,7 @@ JET_SIDE_MENU_COMPACT = True
 JET_DEFAULT_THEME = "jdav-green"
 JET_CHANGE_FORM_SIBLING_LINKS = False
 
-JET_SIDE_MENU_ITEMS = [
+_JET_SIDE_MENU_ITEMS = [
     {
         "label": "Teilnehmer*innenverwaltung",
         "app_label": "members",
@@ -104,4 +104,8 @@ JET_SIDE_MENU_ITEMS = [
             {"name": "link", "permissions": ["startpage.view_link"]},
         ],
     },
+]
+
+JET_SIDE_MENU_ITEMS = [
+    item for item in _JET_SIDE_MENU_ITEMS if item.get("app_label") not in SIDEBAR_DISABLED_APPS
 ]

--- a/jdav_web/jdav_web/settings/local.py
+++ b/jdav_web/jdav_web/settings/local.py
@@ -92,6 +92,12 @@ ROOT_SECTION = get_var("startpage", "root_section", default="about")
 RECENT_SECTION = get_var("startpage", "recent_section", default="recent")
 REPORTS_SECTION = get_var("startpage", "reports_section", default="reports")
 
+# sidebar
+
+# List of app labels whose sidebar sections should be hidden.
+# Example: disabled_apps = ["ludwigsburgalpin", "material"]
+SIDEBAR_DISABLED_APPS = get_var("sidebar", "disabled_apps", default=[])
+
 # testing
 
 TEST_MAIL = get_var("testing", "mail", default="test@localhost")


### PR DESCRIPTION
Add a `disabled_apps` setting to disable the sidebar section of all apps in the list.

Closes #242.