### PR TITLE
fix: use POST requests for logging out

### DIFF
--- a/jdav_web/templates/admin/base.html
+++ b/jdav_web/templates/admin/base.html
@@ -81,7 +81,7 @@ django.gettext = window.gettext
                 {% if user.has_usable_password %}
                 <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
                 {% endif %}
-                <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+                <a href="{% url 'admin:logout' %}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">{% trans 'Log out' %}</a>
             {% endblock %}
         </div>
         {% endif %}
@@ -217,7 +217,7 @@ django.gettext = window.gettext
                             </span>
                         </a>
                         {% endif %}
-                        <a href="{% url 'admin:logout' %}" class="sidebar-link icon">
+                        <a href="{% url 'admin:logout' %}" class="sidebar-link icon" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                             <span class="sidebar-link-label">
                                 <span class="sidebar-link-icon icon-cross"></span>
                                 {% trans 'Log out' %}
@@ -466,5 +466,6 @@ django.gettext = window.gettext
 </div>
 <!-- END Container -->
 
+<form id="logout-form" method="post" action="{% url 'admin:logout' %}" style="display:none">{% csrf_token %}</form>
 </body>
 </html>{% endblock %}


### PR DESCRIPTION
The logout endpoint throws a 405 since the recent upgrade to Django 5, because GET requests were removed. See https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0

Closes #268 