### PR TITLE
fix(ci): use base branch ref instead of branch ref for deploy dispatch

### DIFF
--- a/.github/workflows/build-test-shared.yml
+++ b/.github/workflows/build-test-shared.yml
@@ -199,7 +199,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'deploy-pr.yml',
-                ref: '${{ inputs.head_ref }}',
+                ref: '${{ github.ref_name }}',
                 inputs: {
                   pr_number: prNumber.toString()
                 }


### PR DESCRIPTION
When a PR comes from a fork, `inputs.head_ref` resolves to an unknown ref because it is resolved on the main repository. The `ref` field is only relevant for which workflow file should be used, not for which code is deployed.

Note: This makes it harder to test the deploy workflow.