### PR TITLE
feat(members): allow overriding alternative email confirmation

### DIFF
--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -1170,9 +1170,7 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
                     % {"name": member.name},
                 )
                 return HttpResponseRedirect(
-                    reverse(
-                        "admin:members_memberunconfirmedproxy_change", args=(member.pk,)
-                    )
+                    reverse("admin:members_memberunconfirmedproxy_change", args=(member.pk,))
                 )
         else:
             form = ForceConfirmForm()

--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -909,6 +909,16 @@ class DemoteToWaiterForm(forms.Form):
     _selected_action = forms.CharField(widget=forms.MultipleHiddenInput)
 
 
+class ForceConfirmForm(forms.Form):
+    confirm_override = forms.BooleanField(
+        label=_(
+            "I confirm that I want to manually override the missing confirmation of the "
+            "alternative email address."
+        ),
+        required=True,
+    )
+
+
 class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdmin):
     documentation_url = "user_manual/waitinglist.html"
     extra_buttons_model = MemberUnconfirmedProxy
@@ -1135,6 +1145,47 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
             object=member,
         )
         return render(request, "admin/request_registration_form.html", context=context)
+
+    @extra_button(
+        _("Force confirm (override alt. email)"),
+        url_name="force_confirm",
+        condition=lambda obj: bool(obj.alternative_email) and not obj.confirmed_alternative_mail,
+    )
+    def force_confirm_view(self, request, member):
+        if "apply" in request.POST:
+            form = ForceConfirmForm(request.POST)
+            if form.is_valid():
+                if member.force_confirm():
+                    messages.success(
+                        request,
+                        _("Successfully confirmed %(name)s (alternative email override).")
+                        % {"name": member.name},
+                    )
+                    return HttpResponseRedirect(
+                        reverse("admin:members_memberunconfirmedproxy_changelist")
+                    )
+                messages.error(
+                    request,
+                    _("Can't confirm. %(name)s still has an unconfirmed primary email address.")
+                    % {"name": member.name},
+                )
+                return HttpResponseRedirect(
+                    reverse(
+                        "admin:members_memberunconfirmedproxy_change", args=(member.pk,)
+                    )
+                )
+        else:
+            form = ForceConfirmForm()
+        context = dict(
+            self.admin_site.each_context(request),
+            title=_("Force confirm registration"),
+            view_header=_("Force confirm registration"),
+            opts=self.opts,
+            member=member,
+            object=member,
+            form=form,
+        )
+        return render(request, "admin/force_confirm.html", context=context)
 
     def response_change(self, request, member):
         if "_confirm" in request.POST:

--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -1146,34 +1146,7 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
         )
         return render(request, "admin/request_registration_form.html", context=context)
 
-    @extra_button(
-        _("Force confirm (override alt. email)"),
-        url_name="force_confirm",
-        condition=lambda obj: bool(obj.alternative_email) and not obj.confirmed_alternative_mail,
-    )
-    def force_confirm_view(self, request, member):
-        if "apply" in request.POST:
-            form = ForceConfirmForm(request.POST)
-            if form.is_valid():
-                if member.force_confirm():
-                    messages.success(
-                        request,
-                        _("Successfully confirmed %(name)s (alternative email override).")
-                        % {"name": member.name},
-                    )
-                    return HttpResponseRedirect(
-                        reverse("admin:members_memberunconfirmedproxy_changelist")
-                    )
-                messages.error(
-                    request,
-                    _("Can't confirm. %(name)s still has an unconfirmed primary email address.")
-                    % {"name": member.name},
-                )
-                return HttpResponseRedirect(
-                    reverse("admin:members_memberunconfirmedproxy_change", args=(member.pk,))
-                )
-        else:
-            form = ForceConfirmForm()
+    def _render_force_confirm(self, request, member, form):
         context = dict(
             self.admin_site.each_context(request),
             title=_("Force confirm registration"),
@@ -1186,7 +1159,33 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
         return render(request, "admin/force_confirm.html", context=context)
 
     def response_change(self, request, member):
+        if "_force_confirm" in request.POST:
+            form = ForceConfirmForm(request.POST)
+            if not form.is_valid():
+                return self._render_force_confirm(request, member, form)
+            if member.force_confirm():
+                messages.success(
+                    request, _("Successfully confirmed %(name)s.") % {"name": member.name}
+                )
+                return HttpResponseRedirect(
+                    reverse("admin:members_memberunconfirmedproxy_changelist")
+                )
+            messages.error(
+                request,
+                _("Can't confirm. %(name)s has an unconfirmed primary email address.")
+                % {"name": member.name},
+            )
+            return super().response_change(request, member)
         if "_confirm" in request.POST:
+            if not member.confirmed_mail:
+                messages.error(
+                    request,
+                    _("Can't confirm. %(name)s has unconfirmed email addresses.")
+                    % {"name": member.name},
+                )
+                return super().response_change(request, member)
+            if member.alternative_email and not member.confirmed_alternative_mail:
+                return self._render_force_confirm(request, member, ForceConfirmForm())
             if member.confirm():
                 messages.success(
                     request, _("Successfully confirmed %(name)s.") % {"name": member.name}

--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -1146,6 +1146,17 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
         )
         return render(request, "admin/request_registration_form.html", context=context)
 
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<path:object_id>/force-confirm/",
+                self.admin_site.admin_view(self.force_confirm_view),
+                name="members_memberunconfirmedproxy_force_confirm",
+            ),
+        ]
+        return custom_urls + urls
+
     def _render_force_confirm(self, request, member, form):
         context = dict(
             self.admin_site.each_context(request),
@@ -1158,24 +1169,41 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
         )
         return render(request, "admin/force_confirm.html", context=context)
 
-    def response_change(self, request, member):
-        if "_force_confirm" in request.POST:
+    def force_confirm_view(self, request, object_id):
+        """Intermediate confirmation view for overriding the missing
+        confirmation of the alternative email. The registration has already
+        been saved at this point, so the override is handled independently of
+        the change form to avoid re-validating it."""
+        member = self.get_object(request, object_id)
+        if member is None:
+            messages.error(request, _("Registration not found."))
+            return HttpResponseRedirect(reverse("admin:members_memberunconfirmedproxy_changelist"))
+        if not self.has_change_permission(request, member):
+            messages.error(request, _("Insufficient permissions."))
+            return HttpResponseRedirect(reverse("admin:members_memberunconfirmedproxy_changelist"))
+        if request.method == "POST":
             form = ForceConfirmForm(request.POST)
-            if not form.is_valid():
-                return self._render_force_confirm(request, member, form)
-            if member.force_confirm():
-                messages.success(
-                    request, _("Successfully confirmed %(name)s.") % {"name": member.name}
+            if form.is_valid():
+                if member.force_confirm():
+                    messages.success(
+                        request, _("Successfully confirmed %(name)s.") % {"name": member.name}
+                    )
+                    return HttpResponseRedirect(
+                        reverse("admin:members_memberunconfirmedproxy_changelist")
+                    )
+                messages.error(
+                    request,
+                    _("Can't confirm. %(name)s has an unconfirmed primary email address.")
+                    % {"name": member.name},
                 )
                 return HttpResponseRedirect(
-                    reverse("admin:members_memberunconfirmedproxy_changelist")
+                    reverse("admin:members_memberunconfirmedproxy_change", args=(member.pk,))
                 )
-            messages.error(
-                request,
-                _("Can't confirm. %(name)s has an unconfirmed primary email address.")
-                % {"name": member.name},
-            )
-            return super().response_change(request, member)
+        else:
+            form = ForceConfirmForm()
+        return self._render_force_confirm(request, member, form)
+
+    def response_change(self, request, member):
         if "_confirm" in request.POST:
             if not member.confirmed_mail:
                 messages.error(
@@ -1185,7 +1213,9 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
                 )
                 return super().response_change(request, member)
             if member.alternative_email and not member.confirmed_alternative_mail:
-                return self._render_force_confirm(request, member, ForceConfirmForm())
+                return HttpResponseRedirect(
+                    reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(member.pk,))
+                )
             if member.confirm():
                 messages.success(
                     request, _("Successfully confirmed %(name)s.") % {"name": member.name}

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -306,20 +306,11 @@ msgstr "Anmeldeformular für %(name)s angefragt."
 msgid "Request upload registration form"
 msgstr "Anmeldeformular anfragen"
 
-msgid "Force confirm (override alt. email)"
-msgstr "Bestätigung erzwingen (alt. E-Mail übergehen)"
-
 #, python-format
-msgid "Successfully confirmed %(name)s (alternative email override)."
+msgid "Can't confirm. %(name)s has an unconfirmed primary email address."
 msgstr ""
-"Registrierung von %(name)s erfolgreich bestätigt (alternative E-Mail "
-"übergangen)."
-
-#, python-format
-msgid "Can't confirm. %(name)s still has an unconfirmed primary email address."
-msgstr ""
-"Bestätigung nicht möglich. %(name)s hat noch eine unbestätigte primäre E-"
-"Mail-Adresse."
+"Bestätigung nicht möglich. %(name)s hat eine unbestätigte primäre E-Mail-"
+"Adresse."
 
 msgid "Force confirm registration"
 msgstr "Registrierung erzwungen bestätigen"
@@ -1249,14 +1240,6 @@ msgstr ""
 "Du kannst die fehlende Bestätigung der alternativen E-Mail-Adresse manuell "
 "übergehen. Die Registrierung wird bestätigt und die alternative E-Mail-"
 "Adresse wird als bestätigt markiert."
-
-#, python-format
-msgid ""
-"Warning: The primary email of %(member)s is also not confirmed. Confirmation "
-"is not possible."
-msgstr ""
-"Warnung: Die primäre E-Mail-Adresse von %(member)s ist ebenfalls nicht "
-"bestätigt. Eine Bestätigung ist nicht möglich."
 
 msgid "Force confirm"
 msgstr "Bestätigung erzwingen"

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-03 19:42+0200\n"
+"POT-Creation-Date: 2026-06-30 00:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -235,6 +235,13 @@ msgstr "Ungültige Teilnehmer*innenauswahl."
 msgid "Create Crisis Intervention List"
 msgstr "Kriseninterventionsliste erstellen"
 
+msgid ""
+"I confirm that I want to manually override the missing confirmation of the "
+"alternative email address."
+msgstr ""
+"Ich bestätige, dass ich die fehlende Bestätigung der alternativen E-Mail-"
+"Adresse manuell übergehen möchte."
+
 msgid "Alternative email confirmed"
 msgstr "Alternative E-Mail Adresse bestätigt"
 
@@ -298,6 +305,24 @@ msgstr "Anmeldeformular für %(name)s angefragt."
 
 msgid "Request upload registration form"
 msgstr "Anmeldeformular anfragen"
+
+msgid "Force confirm (override alt. email)"
+msgstr "Bestätigung erzwingen (alt. E-Mail übergehen)"
+
+#, python-format
+msgid "Successfully confirmed %(name)s (alternative email override)."
+msgstr ""
+"Registrierung von %(name)s erfolgreich bestätigt (alternative E-Mail "
+"übergangen)."
+
+#, python-format
+msgid "Can't confirm. %(name)s still has an unconfirmed primary email address."
+msgstr ""
+"Bestätigung nicht möglich. %(name)s hat noch eine unbestätigte primäre E-"
+"Mail-Adresse."
+
+msgid "Force confirm registration"
+msgstr "Registrierung erzwungen bestätigen"
 
 msgid "Group"
 msgstr "Gruppe"
@@ -1207,6 +1232,34 @@ msgstr "Möchtest du die folgenden Personen zurück auf die Warteliste setzen?"
 
 msgid "Demote"
 msgstr "Zurück auf die Warteliste setzen"
+
+#, python-format
+msgid ""
+"The alternative email of %(member)s (%(member.alternative_email)s) has not "
+"been confirmed."
+msgstr ""
+"Die alternative E-Mail-Adresse von %(member)s (%(member.alternative_email)s) "
+"wurde nicht bestätigt."
+
+msgid ""
+"You can manually override the missing confirmation of the alternative email. "
+"The registration will be confirmed and the alternative email will be marked "
+"as confirmed."
+msgstr ""
+"Du kannst die fehlende Bestätigung der alternativen E-Mail-Adresse manuell "
+"übergehen. Die Registrierung wird bestätigt und die alternative E-Mail-"
+"Adresse wird als bestätigt markiert."
+
+#, python-format
+msgid ""
+"Warning: The primary email of %(member)s is also not confirmed. Confirmation "
+"is not possible."
+msgstr ""
+"Warnung: Die primäre E-Mail-Adresse von %(member)s ist ebenfalls nicht "
+"bestätigt. Eine Bestätigung ist nicht möglich."
+
+msgid "Force confirm"
+msgstr "Bestätigung erzwingen"
 
 msgid ""
 "\n"

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:32+0200\n"
+"POT-Creation-Date: 2026-06-30 00:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -308,6 +308,12 @@ msgstr "Anmeldeformular anfragen"
 
 msgid "Force confirm registration"
 msgstr "Registrierung erzwungen bestätigen"
+
+msgid "Registration not found."
+msgstr "Registrierung nicht gefunden."
+
+msgid "Insufficient permissions."
+msgstr "Unzureichende Berechtigungen."
 
 #, python-format
 msgid "Can't confirm. %(name)s has an unconfirmed primary email address."
@@ -2079,9 +2085,6 @@ msgid ""
 msgstr ""
 "Danke %(prename)s für dein Interesse auf der Warteliste zu bleiben.\n"
 "Dein Platz wurde bestätigt."
-
-msgid "Insufficient permissions."
-msgstr "Unzureichende Berechtigungen."
 
 msgid "Member not found."
 msgstr "Teilnehmer*in nicht gefunden."

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:11+0200\n"
+"POT-Creation-Date: 2026-06-30 00:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -306,14 +306,14 @@ msgstr "Anmeldeformular für %(name)s angefragt."
 msgid "Request upload registration form"
 msgstr "Anmeldeformular anfragen"
 
+msgid "Force confirm registration"
+msgstr "Registrierung erzwungen bestätigen"
+
 #, python-format
 msgid "Can't confirm. %(name)s has an unconfirmed primary email address."
 msgstr ""
 "Bestätigung nicht möglich. %(name)s hat eine unbestätigte primäre E-Mail-"
 "Adresse."
-
-msgid "Force confirm registration"
-msgstr "Registrierung erzwungen bestätigen"
 
 msgid "Group"
 msgstr "Gruppe"

--- a/jdav_web/members/models/member.py
+++ b/jdav_web/members/models/member.py
@@ -230,6 +230,17 @@ class Member(Person):
         self.save()
         return True
 
+    def force_confirm(self):
+        """Confirm the registration, overriding the requirement that the
+        alternative email be confirmed. The primary email must still be
+        confirmed."""
+        if not self.confirmed_mail:
+            return False
+        self.confirmed_alternative_mail = True
+        self.confirmed = True
+        self.save()
+        return True
+
     def unconfirm(self):
         self.confirmed = False
         self.save()

--- a/jdav_web/members/templates/admin/force_confirm.html
+++ b/jdav_web/members/templates/admin/force_confirm.html
@@ -9,17 +9,12 @@
 <p>
 {% blocktrans %}You can manually override the missing confirmation of the alternative email. The registration will be confirmed and the alternative email will be marked as confirmed.{% endblocktrans %}
 </p>
-{% if not member.confirmed_mail %}
-<p>
-<strong>{% blocktrans %}Warning: The primary email of {{ member }} is also not confirmed. Confirmation is not possible.{% endblocktrans %}</strong>
-</p>
-{% endif %}
 
 <form action="" method="post">
     {% csrf_token %}
     {{ form }}
     <p>
-        <input class="default" type="submit" name="apply" value="{% translate 'Force confirm' %}">
+        <input class="default" type="submit" name="_force_confirm" value="{% translate 'Force confirm' %}">
         <a href="#" class="button cancel-link">{% translate "Cancel" %}</a>
     </p>
 </form>

--- a/jdav_web/members/templates/admin/force_confirm.html
+++ b/jdav_web/members/templates/admin/force_confirm.html
@@ -1,0 +1,26 @@
+{% extends "admin/extra_view.html" %}
+{% load i18n %}
+
+{% block content %}
+<h2>{% translate "Force confirm registration" %}</h2>
+<p>
+{% blocktrans %}The alternative email of {{ member }} ({{ member.alternative_email }}) has not been confirmed.{% endblocktrans %}
+</p>
+<p>
+{% blocktrans %}You can manually override the missing confirmation of the alternative email. The registration will be confirmed and the alternative email will be marked as confirmed.{% endblocktrans %}
+</p>
+{% if not member.confirmed_mail %}
+<p>
+<strong>{% blocktrans %}Warning: The primary email of {{ member }} is also not confirmed. Confirmation is not possible.{% endblocktrans %}</strong>
+</p>
+{% endif %}
+
+<form action="" method="post">
+    {% csrf_token %}
+    {{ form }}
+    <p>
+        <input class="default" type="submit" name="apply" value="{% translate 'Force confirm' %}">
+        <a href="#" class="button cancel-link">{% translate "Cancel" %}</a>
+    </p>
+</form>
+{% endblock %}

--- a/jdav_web/members/templates/admin/force_confirm.html
+++ b/jdav_web/members/templates/admin/force_confirm.html
@@ -10,9 +10,12 @@
 {% blocktrans %}You can manually override the missing confirmation of the alternative email. The registration will be confirmed and the alternative email will be marked as confirmed.{% endblocktrans %}
 </p>
 
-<form action="" method="post">
+<form action="{% url 'admin:members_memberunconfirmedproxy_force_confirm' member.pk %}" method="post">
     {% csrf_token %}
-    {{ form }}
+    <div class="form-row">
+        {{ form.confirm_override.errors }}
+        {{ form.confirm_override }}{{ form.confirm_override.label_tag }}
+    </div>
     <p>
         <input class="default" type="submit" name="_force_confirm" value="{% translate 'Force confirm' %}">
         <a href="#" class="button cancel-link">{% translate "Cancel" %}</a>

--- a/jdav_web/members/tests/basic.py
+++ b/jdav_web/members/tests/basic.py
@@ -2513,6 +2513,65 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
+    def test_force_confirm_get(self):
+        c = self._login("superuser")
+        self.reg.alternative_email = "alt@example.com"
+        self.reg.confirmed_mail = True
+        self.reg.confirmed_alternative_mail = False
+        self.reg.save()
+        url = reverse(
+            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
+        )
+        response = c.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(response, _("Force confirm registration"))
+
+    def test_force_confirm_requires_checkbox(self):
+        c = self._login("superuser")
+        self.reg.alternative_email = "alt@example.com"
+        self.reg.confirmed_mail = True
+        self.reg.confirmed_alternative_mail = False
+        self.reg.save()
+        url = reverse(
+            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
+        )
+        response = c.post(url, data={"apply": ""})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.reg.refresh_from_db()
+        self.assertFalse(self.reg.confirmed)
+        self.assertFalse(self.reg.confirmed_alternative_mail)
+
+    def test_force_confirm_applies(self):
+        c = self._login("superuser")
+        self.reg.alternative_email = "alt@example.com"
+        self.reg.confirmed_mail = True
+        self.reg.confirmed_alternative_mail = False
+        self.reg.save()
+        url = reverse(
+            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
+        )
+        response = c.post(url, data={"apply": "", "confirm_override": "on"})
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.reg.refresh_from_db()
+        self.assertTrue(self.reg.confirmed)
+        self.assertTrue(self.reg.confirmed_alternative_mail)
+
+    def test_force_confirm_without_primary_mail(self):
+        c = self._login("superuser")
+        self.reg.alternative_email = "alt@example.com"
+        self.reg.confirmed_mail = False
+        self.reg.confirmed_alternative_mail = False
+        self.reg.save()
+        url = reverse(
+            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
+        )
+        response = c.post(
+            url, data={"apply": "", "confirm_override": "on"}, follow=True
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.reg.refresh_from_db()
+        self.assertFalse(self.reg.confirmed)
+
     def test_confirm(self):
         c = self._login("superuser")
         url = reverse("admin:members_memberunconfirmedproxy_changelist")

--- a/jdav_web/members/tests/basic.py
+++ b/jdav_web/members/tests/basic.py
@@ -2513,54 +2513,63 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
-    def test_force_confirm_get(self):
-        c = self._login("superuser")
+    def test_confirm_renders_force_confirm_when_alt_mail_unconfirmed(self):
         self.reg.alternative_email = "alt@example.com"
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
-        response = c.get(url)
+        request = self.factory.post("/", {"_confirm": True})
+        request.user = User.objects.get(username="superuser")
+        self._add_session_to_request(request)
+        response = self.admin.response_change(request, self.reg)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, _("Force confirm registration"))
+        self.reg.refresh_from_db()
+        self.assertFalse(self.reg.confirmed)
+        self.assertFalse(self.reg.confirmed_alternative_mail)
 
     def test_force_confirm_requires_checkbox(self):
-        c = self._login("superuser")
         self.reg.alternative_email = "alt@example.com"
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
-        response = c.post(url, data={"apply": ""})
+        request = self.factory.post("/", {"_force_confirm": True})
+        request.user = User.objects.get(username="superuser")
+        self._add_session_to_request(request)
+        response = self.admin.response_change(request, self.reg)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.reg.refresh_from_db()
         self.assertFalse(self.reg.confirmed)
         self.assertFalse(self.reg.confirmed_alternative_mail)
 
     def test_force_confirm_applies(self):
-        c = self._login("superuser")
         self.reg.alternative_email = "alt@example.com"
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
-        response = c.post(url, data={"apply": "", "confirm_override": "on"})
+        request = self.factory.post("/", {"_force_confirm": True, "confirm_override": "on"})
+        request.user = User.objects.get(username="superuser")
+        self._add_session_to_request(request)
+        response = self.admin.response_change(request, self.reg)
         self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.reg.refresh_from_db()
         self.assertTrue(self.reg.confirmed)
         self.assertTrue(self.reg.confirmed_alternative_mail)
 
-    def test_force_confirm_without_primary_mail(self):
-        c = self._login("superuser")
+    def test_confirm_fails_without_primary_mail(self):
         self.reg.alternative_email = "alt@example.com"
         self.reg.confirmed_mail = False
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
-        response = c.post(url, data={"apply": "", "confirm_override": "on"}, follow=True)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
+        request = self.factory.post("/", {"_confirm": True})
+        request.user = User.objects.get(username="superuser")
+        self._add_session_to_request(request)
+        with mock.patch("members.admin.super") as mock_super:
+            mock_super.return_value.response_change.return_value = HttpResponse()
+            self.admin.response_change(request, self.reg)
         self.reg.refresh_from_db()
         self.assertFalse(self.reg.confirmed)
+        self.assertFalse(self.reg.confirmed_alternative_mail)
 
     def test_confirm(self):
         c = self._login("superuser")

--- a/jdav_web/members/tests/basic.py
+++ b/jdav_web/members/tests/basic.py
@@ -2519,9 +2519,7 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse(
-            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
-        )
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
         response = c.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, _("Force confirm registration"))
@@ -2532,9 +2530,7 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse(
-            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
-        )
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
         response = c.post(url, data={"apply": ""})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.reg.refresh_from_db()
@@ -2547,9 +2543,7 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse(
-            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
-        )
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
         response = c.post(url, data={"apply": "", "confirm_override": "on"})
         self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.reg.refresh_from_db()
@@ -2562,12 +2556,8 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         self.reg.confirmed_mail = False
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        url = reverse(
-            "admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)
-        )
-        response = c.post(
-            url, data={"apply": "", "confirm_override": "on"}, follow=True
-        )
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
+        response = c.post(url, data={"apply": "", "confirm_override": "on"}, follow=True)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.reg.refresh_from_db()
         self.assertFalse(self.reg.confirmed)

--- a/jdav_web/members/tests/basic.py
+++ b/jdav_web/members/tests/basic.py
@@ -2513,7 +2513,7 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
-    def test_confirm_renders_force_confirm_when_alt_mail_unconfirmed(self):
+    def test_confirm_redirects_to_force_confirm_when_alt_mail_unconfirmed(self):
         self.reg.alternative_email = "alt@example.com"
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
@@ -2522,39 +2522,66 @@ class MemberUnconfirmedAdminTestCase(AdminTestCase):
         request.user = User.objects.get(username="superuser")
         self._add_session_to_request(request)
         response = self.admin.response_change(request, self.reg)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertContains(response, _("Force confirm registration"))
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertEqual(
+            response.url,
+            reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,)),
+        )
         self.reg.refresh_from_db()
         self.assertFalse(self.reg.confirmed)
         self.assertFalse(self.reg.confirmed_alternative_mail)
 
-    def test_force_confirm_requires_checkbox(self):
+    def test_force_confirm_get_renders_checkbox(self):
+        c = self._login("superuser")
         self.reg.alternative_email = "alt@example.com"
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        request = self.factory.post("/", {"_force_confirm": True})
-        request.user = User.objects.get(username="superuser")
-        self._add_session_to_request(request)
-        response = self.admin.response_change(request, self.reg)
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
+        response = c.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(response, _("Force confirm registration"))
+        self.assertContains(response, 'type="checkbox"')
+        self.assertContains(response, "confirm_override")
+
+    def test_force_confirm_requires_checkbox(self):
+        c = self._login("superuser")
+        self.reg.alternative_email = "alt@example.com"
+        self.reg.confirmed_mail = True
+        self.reg.confirmed_alternative_mail = False
+        self.reg.save()
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
+        response = c.post(url, data={})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.reg.refresh_from_db()
         self.assertFalse(self.reg.confirmed)
         self.assertFalse(self.reg.confirmed_alternative_mail)
 
     def test_force_confirm_applies(self):
+        c = self._login("superuser")
         self.reg.alternative_email = "alt@example.com"
         self.reg.confirmed_mail = True
         self.reg.confirmed_alternative_mail = False
         self.reg.save()
-        request = self.factory.post("/", {"_force_confirm": True, "confirm_override": "on"})
-        request.user = User.objects.get(username="superuser")
-        self._add_session_to_request(request)
-        response = self.admin.response_change(request, self.reg)
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
+        response = c.post(url, data={"confirm_override": "on"})
         self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.reg.refresh_from_db()
         self.assertTrue(self.reg.confirmed)
         self.assertTrue(self.reg.confirmed_alternative_mail)
+
+    def test_force_confirm_fails_without_primary_mail(self):
+        c = self._login("superuser")
+        self.reg.alternative_email = "alt@example.com"
+        self.reg.confirmed_mail = False
+        self.reg.confirmed_alternative_mail = False
+        self.reg.save()
+        url = reverse("admin:members_memberunconfirmedproxy_force_confirm", args=(self.reg.pk,))
+        response = c.post(url, data={"confirm_override": "on"})
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.reg.refresh_from_db()
+        self.assertFalse(self.reg.confirmed)
+        self.assertFalse(self.reg.confirmed_alternative_mail)
 
     def test_confirm_fails_without_primary_mail(self):
         self.reg.alternative_email = "alt@example.com"


### PR DESCRIPTION
## Summary

Closes #286.

Sometimes the alternative email cannot be delivered/confirmed, which currently blocks finalizing the registration. This PR adds an intermediate admin view that lets staff manually override the missing confirmation of the alternative email.

- New `Member.force_confirm()` method which confirms a registration while marking the alternative email as confirmed. The primary email must still be confirmed.
- New `force_confirm_view` (an `@extra_button` view) on `MemberUnconfirmedAdmin`. The button only shows when the registration has an alternative email that is not yet confirmed.
- The view renders an intermediate template with a required checkbox (`ForceConfirmForm`) that asks for explicit user confirmation before performing the override.
- Tests covering the GET view, missing checkbox, successful override, and the case where the primary email is also unconfirmed.

## Test plan

- [ ] Open an unconfirmed registration where the alternative email is set but not confirmed; verify the "Force confirm (override alt. email)" button appears.
- [ ] Submit the form without the checkbox; verify the registration stays unconfirmed.
- [ ] Submit the form with the checkbox; verify the registration is confirmed and the alternative email is marked as confirmed.
- [ ] Verify the button does not appear when there is no alternative email or when it is already confirmed.
