### PR TITLE
feat(members/admin): allow overriding alt email confirmation for registrations

### DIFF
--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -909,6 +909,17 @@ class DemoteToWaiterForm(forms.Form):
     _selected_action = forms.CharField(widget=forms.MultipleHiddenInput)
 
 
+class ConfirmOverrideAltEmailForm(forms.Form):
+    _selected_action = forms.CharField(widget=forms.MultipleHiddenInput, required=False)
+    confirm_override = forms.BooleanField(
+        label=_(
+            "I confirm that I want to override the missing alternative email confirmation"
+            " and have verified the alternative email address manually."
+        ),
+        required=True,
+    )
+
+
 class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdmin):
     documentation_url = "user_manual/waitinglist.html"
     extra_buttons_model = MemberUnconfirmedProxy
@@ -1043,9 +1054,41 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
     )
 
     def confirm(self, request, queryset):
+        # Override form submission: "apply" is set by the intermediate override view.
+        if "apply" in request.POST:
+            form = ConfirmOverrideAltEmailForm(request.POST)
+            if form.is_valid():
+                for member in queryset:
+                    if member.confirm(override_alternative_email=True):
+                        messages.success(
+                            request,
+                            _("Successfully confirmed %(name)s.") % {"name": member.name},
+                        )
+                    else:
+                        messages.error(
+                            request,
+                            _("Can't confirm. %(name)s has an unconfirmed primary email.")
+                            % {"name": member.name},
+                        )
+                return
+            # Checkbox not checked – re-render the intermediate view with errors.
+            context = dict(
+                self.admin_site.each_context(request),
+                title=_("Override alternative email confirmation"),
+                opts=self.opts,
+                queryset=queryset,
+                form=form,
+            )
+            return render(request, "admin/confirm_override_alt_email.html", context=context)
+
         notify_individual = len(queryset.all()) < 10
         success = True
+        members_needing_override = []
+
         for member in queryset:
+            if member.confirmed_mail and not member.confirmed_alternative_mail and member.alternative_email:
+                members_needing_override.append(member)
+                continue
             confirmed = member.confirm()
             if not confirmed:
                 success = False
@@ -1060,15 +1103,27 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
                         _("Can't confirm. %(name)s has unconfirmed email addresses.")
                         % {"name": member.name},
                     )
-        if notify_individual:
-            return
-        if success:
-            messages.success(request, _("Successfully confirmed multiple registrations."))
-        else:
-            messages.error(
-                request,
-                _("Failed to confirm some registrations because of unconfirmed email addresses."),
+
+        if members_needing_override:
+            ids = [m.pk for m in members_needing_override]
+            form = ConfirmOverrideAltEmailForm(initial={"_selected_action": ids})
+            context = dict(
+                self.admin_site.each_context(request),
+                title=_("Override alternative email confirmation"),
+                opts=self.opts,
+                queryset=members_needing_override,
+                form=form,
             )
+            return render(request, "admin/confirm_override_alt_email.html", context=context)
+
+        if not notify_individual:
+            if success:
+                messages.success(request, _("Successfully confirmed multiple registrations."))
+            else:
+                messages.error(
+                    request,
+                    _("Failed to confirm some registrations because of unconfirmed email addresses."),
+                )
 
     confirm.short_description = _("Confirm selected registrations")
 
@@ -1114,6 +1169,49 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
             )
 
     @extra_button(
+        _("Confirm (override alternative email)"),
+        url_name="confirm_override_alt_email",
+        condition=lambda obj: not obj.confirmed
+        and obj.confirmed_mail
+        and not obj.confirmed_alternative_mail
+        and bool(obj.alternative_email),
+        documentation_url="user_manual/waitinglist.html",
+    )
+    def confirm_override_alt_email_view(self, request, member):
+        if "apply" in request.POST:
+            form = ConfirmOverrideAltEmailForm(request.POST)
+            if form.is_valid():
+                if member.confirm(override_alternative_email=True):
+                    messages.success(
+                        request,
+                        _("Successfully confirmed %(name)s.") % {"name": member.name},
+                    )
+                else:
+                    messages.error(
+                        request,
+                        _("Can't confirm. %(name)s has an unconfirmed primary email.")
+                        % {"name": member.name},
+                    )
+                return HttpResponseRedirect(
+                    reverse("admin:members_memberunconfirmedproxy_change", args=(member.pk,))
+                )
+        else:
+            form = ConfirmOverrideAltEmailForm()
+
+        context = dict(
+            self.admin_site.each_context(request),
+            title=_("Override alternative email confirmation"),
+            view_header=_("Confirm (override alternative email)"),
+            opts=self.opts,
+            member=member,
+            object=member,
+            queryset=[member],
+            form=form,
+            is_single=True,
+        )
+        return render(request, "admin/confirm_override_alt_email.html", context=context)
+
+    @extra_button(
         _("Request registration form"),
         documentation_url="user_manual/waitinglist.html",
     )
@@ -1138,7 +1236,20 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
 
     def response_change(self, request, member):
         if "_confirm" in request.POST:
-            if member.confirm():
+            if not member.confirmed_mail:
+                messages.error(
+                    request,
+                    _("Can't confirm. %(name)s has unconfirmed email addresses.")
+                    % {"name": member.name},
+                )
+            elif not member.confirmed_alternative_mail and member.alternative_email:
+                return HttpResponseRedirect(
+                    reverse(
+                        "admin:members_memberunconfirmedproxy_confirm_override_alt_email",
+                        args=(member.pk,),
+                    )
+                )
+            elif member.confirm():
                 messages.success(
                     request, _("Successfully confirmed %(name)s.") % {"name": member.name}
                 )

--- a/jdav_web/members/admin.py
+++ b/jdav_web/members/admin.py
@@ -1086,7 +1086,11 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
         members_needing_override = []
 
         for member in queryset:
-            if member.confirmed_mail and not member.confirmed_alternative_mail and member.alternative_email:
+            if (
+                member.confirmed_mail
+                and not member.confirmed_alternative_mail
+                and member.alternative_email
+            ):
                 members_needing_override.append(member)
                 continue
             confirmed = member.confirm()
@@ -1122,7 +1126,10 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
             else:
                 messages.error(
                     request,
-                    _("Failed to confirm some registrations because of unconfirmed email addresses."),
+                    _(
+                        "Failed to confirm some registrations because of unconfirmed email"
+                        " addresses."
+                    ),
                 )
 
     confirm.short_description = _("Confirm selected registrations")
@@ -1171,10 +1178,12 @@ class MemberUnconfirmedAdmin(ExtraButtonsMixin, CommonAdminMixin, admin.ModelAdm
     @extra_button(
         _("Confirm (override alternative email)"),
         url_name="confirm_override_alt_email",
-        condition=lambda obj: not obj.confirmed
-        and obj.confirmed_mail
-        and not obj.confirmed_alternative_mail
-        and bool(obj.alternative_email),
+        condition=lambda obj: (
+            not obj.confirmed
+            and obj.confirmed_mail
+            and not obj.confirmed_alternative_mail
+            and bool(obj.alternative_email)
+        ),
         documentation_url="user_manual/waitinglist.html",
     )
     def confirm_override_alt_email_view(self, request, member):

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -235,6 +235,14 @@ msgstr "Ungültige Teilnehmer*innenauswahl."
 msgid "Create Crisis Intervention List"
 msgstr "Kriseninterventionsliste erstellen"
 
+msgid ""
+"I confirm that I want to override the missing alternative email confirmation "
+"and have verified the alternative email address manually."
+msgstr ""
+"Ich bestätige, dass ich die fehlende Bestätigung der alternativen E-Mail-"
+"Adresse überschreiben möchte und die alternative E-Mail-Adresse manuell "
+"überprüft habe."
+
 msgid "Alternative email confirmed"
 msgstr "Alternative E-Mail Adresse bestätigt"
 
@@ -259,6 +267,15 @@ msgstr ""
 #, python-format
 msgid "Successfully confirmed %(name)s."
 msgstr "Registrierung von %(name)s erfolgreich bestätigt."
+
+#, python-format
+msgid "Can't confirm. %(name)s has an unconfirmed primary email."
+msgstr ""
+"%(name)s kann nicht bestätigt werden. Die primäre E-Mail-Adresse ist nicht "
+"bestätigt."
+
+msgid "Override alternative email confirmation"
+msgstr "Bestätigung der alternativen E-Mail-Adresse überschreiben"
 
 #, python-format
 msgid "Can't confirm. %(name)s has unconfirmed email addresses."
@@ -288,6 +305,9 @@ msgstr "Ausgewählte Registrierung zurück auf die Warteliste setzen."
 #, python-format
 msgid "Successfully demoted %(name)s to waiter."
 msgstr "%(name)s zurück auf die Warteliste gesetzt."
+
+msgid "Confirm (override alternative email)"
+msgstr "Bestätigen (alternative E-Mail überschreiben)"
 
 msgid "Request registration form"
 msgstr "Anmeldeformular anfragen"
@@ -1162,6 +1182,26 @@ msgstr "Von der Warteliste abgemeldet"
 msgid "Successfully registered for the waitinglist"
 msgstr "Erfolgreich für die Warteliste registriert"
 
+msgid "Home"
+msgstr "Start"
+
+msgid ""
+"The following registrations have an unconfirmed alternative email address. "
+"Confirming them requires explicitly overriding this requirement. Please "
+"verify manually that the alternative email address is correct before "
+"proceeding."
+msgstr ""
+"Die folgenden Anmeldungen haben eine unbestätigte alternative E-Mail-"
+"Adresse. Um sie zu bestätigen, muss diese Anforderung explizit überschrieben "
+"werden. Bitte überprüfe die alternative E-Mail-Adresse manuell, bevor du "
+"fortfährst."
+
+msgid "Confirm"
+msgstr "Bestätigen"
+
+msgid "Cancel"
+msgstr "Abbrechen"
+
 msgid "Selected members:"
 msgstr "Ausgewählte Teilnehmer*innen:"
 
@@ -1170,9 +1210,6 @@ msgstr "Bitte gib die Details für die Aktivität ein:"
 
 msgid "Generate Crisis Intervention List"
 msgstr "Kriseninterventionsliste generieren"
-
-msgid "Cancel"
-msgstr "Abbrechen"
 
 msgid "Select object type:"
 msgstr "Wähle Objekttyp:"
@@ -1652,9 +1689,6 @@ msgstr "Möchtest du %(member)s auffordern das Anmeldeformular hochzuladen?"
 msgid "Warning: %(member)s has already uploaded a registration form."
 msgstr "Warnung: %(member)s hat bereits ein Anmeldeformular hochgeladen."
 
-msgid "Home"
-msgstr "Start"
-
 #, python-format
 msgid "Add %(name)s"
 msgstr "%(name)s hinzufügen"
@@ -2092,30 +2126,3 @@ msgstr "Optionale zusätzliche E-Mailadresse"
 
 msgid "Invalid emergency contacts"
 msgstr "Ungültige Notfallkontakte"
-
-msgid ""
-"I confirm that I want to override the missing alternative email confirmation"
-" and have verified the alternative email address manually."
-msgstr ""
-"Ich bestätige, dass ich die fehlende Bestätigung der alternativen E-Mail-"
-"Adresse überschreiben möchte und die alternative E-Mail-Adresse manuell "
-"überprüft habe."
-
-msgid "Override alternative email confirmation"
-msgstr "Bestätigung der alternativen E-Mail-Adresse überschreiben"
-
-msgid "Confirm (override alternative email)"
-msgstr "Bestätigen (alternative E-Mail überschreiben)"
-
-msgid ""
-"The following registrations have an unconfirmed alternative email address. "
-"Confirming them requires explicitly overriding this requirement. "
-"Please verify manually that the alternative email address is correct before "
-"proceeding."
-msgstr ""
-"Die folgenden Anmeldungen haben eine unbestätigte alternative E-Mail-Adresse. "
-"Um sie zu bestätigen, muss diese Anforderung explizit überschrieben werden. "
-"Bitte überprüfe die alternative E-Mail-Adresse manuell, bevor du fortfährst."
-
-msgid "Can't confirm. %(name)s has an unconfirmed primary email."
-msgstr "%(name)s kann nicht bestätigt werden. Die primäre E-Mail-Adresse ist nicht bestätigt."

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -2092,3 +2092,30 @@ msgstr "Optionale zusätzliche E-Mailadresse"
 
 msgid "Invalid emergency contacts"
 msgstr "Ungültige Notfallkontakte"
+
+msgid ""
+"I confirm that I want to override the missing alternative email confirmation"
+" and have verified the alternative email address manually."
+msgstr ""
+"Ich bestätige, dass ich die fehlende Bestätigung der alternativen E-Mail-"
+"Adresse überschreiben möchte und die alternative E-Mail-Adresse manuell "
+"überprüft habe."
+
+msgid "Override alternative email confirmation"
+msgstr "Bestätigung der alternativen E-Mail-Adresse überschreiben"
+
+msgid "Confirm (override alternative email)"
+msgstr "Bestätigen (alternative E-Mail überschreiben)"
+
+msgid ""
+"The following registrations have an unconfirmed alternative email address. "
+"Confirming them requires explicitly overriding this requirement. "
+"Please verify manually that the alternative email address is correct before "
+"proceeding."
+msgstr ""
+"Die folgenden Anmeldungen haben eine unbestätigte alternative E-Mail-Adresse. "
+"Um sie zu bestätigen, muss diese Anforderung explizit überschrieben werden. "
+"Bitte überprüfe die alternative E-Mail-Adresse manuell, bevor du fortfährst."
+
+msgid "Can't confirm. %(name)s has an unconfirmed primary email."
+msgstr "%(name)s kann nicht bestätigt werden. Die primäre E-Mail-Adresse ist nicht bestätigt."

--- a/jdav_web/members/models/member.py
+++ b/jdav_web/members/models/member.py
@@ -223,8 +223,10 @@ class Member(Person):
         self.save()
         return self.echo_key
 
-    def confirm(self):
-        if not self.confirmed_mail or not self.confirmed_alternative_mail:
+    def confirm(self, override_alternative_email=False):
+        if not self.confirmed_mail:
+            return False
+        if not self.confirmed_alternative_mail and not override_alternative_email:
             return False
         self.confirmed = True
         self.save()

--- a/jdav_web/members/templates/admin/confirm_override_alt_email.html
+++ b/jdav_web/members/templates/admin/confirm_override_alt_email.html
@@ -1,0 +1,56 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    <script type="text/javascript" src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
+    <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {% translate 'Override alternative email confirmation' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h2>{% translate "Override alternative email confirmation" %}</h2>
+<p>
+{% blocktrans trimmed %}
+The following registrations have an unconfirmed alternative email address.
+Confirming them requires explicitly overriding this requirement.
+Please verify manually that the alternative email address is correct before proceeding.
+{% endblocktrans %}
+</p>
+
+<ul>
+{% for member in queryset %}
+    <li><strong>{{ member.name }}</strong> &mdash; {{ member.alternative_email }}</li>
+{% endfor %}
+</ul>
+
+<form action="" method="post">
+    {% csrf_token %}
+    {% if not is_single %}
+    {{ form._selected_action }}
+    <input type="hidden" name="action" value="confirm">
+    {% endif %}
+    <p>
+        {{ form.confirm_override }}
+        <label for="{{ form.confirm_override.id_for_label }}">{{ form.confirm_override.label }}</label>
+    </p>
+    {% if form.confirm_override.errors %}
+    <p class="errornote">{{ form.confirm_override.errors }}</p>
+    {% endif %}
+    <input class="default" type="submit" name="apply" value="{% translate 'Confirm' %}">
+    <a href="#" class="button cancel-link">{% translate "Cancel" %}</a>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary

Closes #286

- Adds an intermediate confirmation view when an admin tries to confirm a registration whose alternative email has not yet been confirmed by the member
- The intermediate view lists the affected registrations (name + alternative email address) and requires the admin to check an explicit checkbox before proceeding, replacing the previous hard error
- Three entry points all share the same view/template:
  1. **List action** ("Confirm selected registrations"): confirms members without alt-email issues directly, then redirects to the override view for the remaining ones
  2. **Change form button** ("Save and confirm registration"): when primary email is confirmed but alternative email is not, redirects to the override URL instead of showing an error
  3. **New extra button** ("Confirm (override alternative email)"): shown on the change form only when the condition applies (primary confirmed, alternative unconfirmed), provides a direct path to the override view

## Implementation details

- `Member.confirm(override_alternative_email=False)`: new optional parameter that skips the alternative email check when `True`
- `ConfirmOverrideAltEmailForm`: form with a required `BooleanField` checkbox and an optional `_selected_action` hidden field (used in the list action flow)
- `MemberUnconfirmedAdmin.confirm_override_alt_email_view`: `@extra_button`-decorated view handling both GET and POST for the single-member URL flow
- Template `admin/confirm_override_alt_email.html`: shared by both the action flow and the URL flow (distinguished via `is_single` context variable)
- German translations added for all new strings

## Test plan

- [ ] Confirm a registration with a confirmed primary email but unconfirmed alternative email via the list action → should show the intermediate view with checkbox
- [ ] Submit without checking the checkbox → should re-render with a validation error
- [ ] Submit with the checkbox checked → member should be confirmed
- [ ] Click "Save and confirm registration" on the change form for such a member → should redirect to the override URL
- [ ] Confirm a registration where both emails are confirmed → normal flow unaffected
- [ ] Confirm a registration where the primary email is unconfirmed → error shown as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)