### PR TITLE
ci: bump docker/build-push-action to v6 to fix cache reservation

### DIFF
--- a/.github/workflows/build-test-shared.yml
+++ b/.github/workflows/build-test-shared.yml
@@ -75,7 +75,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build application image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/production/Dockerfile
@@ -130,7 +130,7 @@ jobs:
           done
 
       - name: Build and push nginx image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: docker/production/nginx
           file: docker/production/nginx/Dockerfile


### PR DESCRIPTION
## Problem

The **Build and Test (Fork)** CI check fails in the *Build application image* step with:

```
buildx failed with: ERROR: failed to build: failed to solve:
error writing layer blob: failed to reserve cache
```

This is raised during the cache-export phase (`cache-to: type=gha,mode=max`). It is **not** a cache-quota issue — the repo's Actions cache is nearly empty (~3.7 MB / 10 GB).

## Cause

The workflow used `docker/build-push-action@v5`, whose bundled BuildKit talks to the **retired legacy (v1) GitHub Actions cache API**. GitHub migrated to a new cache service (v2); the old `reserveCache` endpoint no longer works, so the reservation fails.

## Fix

Bump `docker/build-push-action@v5` → `@v6` (both the application and nginx image builds). v6, paired with the recent BuildKit provided by `docker/setup-buildx-action@v3`, uses the new v2 cache protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)