### PR TITLE
feat(members): require DAV membership number in echo form

### DIFF
--- a/docs/source/user_manual/members.rst
+++ b/docs/source/user_manual/members.rst
@@ -145,6 +145,11 @@ Nach erfolgreich eingegebenem Geburtsdatum, wird die Person auf ein Formular mit
 Dann prüfen, gegebenenfalls aktualisieren und schließlich speichern. Der Link ist
 immer 30 Tage lang gültig und kann in dieser Zeit auch beliebig oft benutzt werden.
 
+.. note::
+   Die DAV Mitgliedsnummer ist ein Pflichtfeld der Rückmeldung. Die Rückmeldung kann also nur
+   abgeschickt werden, wenn die DAV Mitgliedsnummer angegeben ist. Sie steht auf dem
+   DAV Mitgliedsausweis.
+
 Klingt alles noch abstrakt? Dann fordere dich doch mal selbst zur Rückmeldung auf und probiere es aus.
 
 .. _emergency-contacts:

--- a/jdav_web/jdav_web/settings/components/texts.py
+++ b/jdav_web/jdav_web/settings/components/texts.py
@@ -218,6 +218,9 @@ Dort kannst du deine Daten nach Eingabe eines Passworts überprüfen und ggf. ä
 Passwort ist dein Geburtsdatum. Wäre dein Geburtsdatum zum Beispiel der 4. Januar 1942,
 so wäre dein Passwort: 04.01.1942
 
+Halte bitte deinen DAV Mitgliedsausweis bereit, denn die Angabe deiner DAV Mitgliedsnummer
+ist für die Rückmeldung verpflichtend.
+
 Falls du nicht innerhalb von 30 Tagen deine Daten bestätigst, gehen wir davon aus, dass du nicht mehr Teil
 unserer Jugendarbeit sein möchtest. Dein Platz wird dann weitervergeben, deine Daten aus unserer Datenbank
 gelöscht und du erhälst in Zukunft keine Mails mehr von uns.

--- a/jdav_web/members/locale/de/LC_MESSAGES/django.po
+++ b/jdav_web/members/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-03 19:42+0200\n"
+"POT-Creation-Date: 2026-08-29 16:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2074,6 +2074,9 @@ msgstr "Nachname des*der Teilnehmenden"
 
 msgid "phone number of child or parent"
 msgstr "Telefonnummer des*der Teilnehmenden oder einer Kontaktperson"
+
+msgid "You can find this number on your DAV membership card."
+msgstr "Diese Nummer findest du auf deinem DAV Mitgliedsausweis."
 
 msgid ""
 "Are we allowed to take photos of you during activities? We use them for our "

--- a/jdav_web/members/tests/basic.py
+++ b/jdav_web/members/tests/basic.py
@@ -96,6 +96,7 @@ from members.tests.utils import add_memberonlist_by_local
 from members.tests.utils import BasicMemberTestCase
 from members.tests.utils import cleanup_excursion
 from members.tests.utils import create_custom_user
+from members.tests.utils import ECHO_DATA
 from members.tests.utils import INTERNAL_EMAIL
 from members.tests.utils import REGISTRATION_DATA
 from members.tests.utils import WAITER_DATA
@@ -3332,7 +3333,7 @@ class EchoViewTestCase(BasicMemberTestCase):
         response = self.client.post(
             url,
             data=dict(
-                REGISTRATION_DATA,
+                ECHO_DATA,
                 key=self.key,
                 password=self.fritz.echo_password,
                 save="",
@@ -3351,7 +3352,7 @@ class EchoViewTestCase(BasicMemberTestCase):
         response = self.client.post(
             url,
             data=dict(
-                REGISTRATION_DATA,
+                ECHO_DATA,
                 **EMERGENCY_CONTACT_DATA,
                 key=self.key,
                 password=self.fritz.echo_password,
@@ -3360,6 +3361,34 @@ class EchoViewTestCase(BasicMemberTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, _("Your data was successfully updated."))
+        self.fritz.refresh_from_db()
+        self.assertEqual(self.fritz.dav_badge_no, ECHO_DATA["dav_badge_no"])
+
+    def test_post_save_without_dav_badge_no(self):
+        # the DAV membership number is mandatory for echoing
+        data = dict(ECHO_DATA, **EMERGENCY_CONTACT_DATA)
+        data["dav_badge_no"] = ""
+        url = reverse("members:echo")
+        response = self.client.post(
+            url,
+            data=dict(
+                data,
+                key=self.key,
+                password=self.fritz.echo_password,
+                save="",
+            ),
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(
+            response,
+            _(
+                "Here is your current data. Please check if it is up to date and change accordingly."
+            ),
+        )
+        self.assertIn("dav_badge_no", response.context["form"].errors)
+        self.fritz.refresh_from_db()
+        self.assertFalse(self.fritz.echoed)
+        self.assertEqual(self.fritz.dav_badge_no, "")
 
     def test_post_save_without_registration_form(self):
         # Clear registration form to test member without registration_form case
@@ -3369,7 +3398,7 @@ class EchoViewTestCase(BasicMemberTestCase):
         response = self.client.post(
             url,
             data=dict(
-                REGISTRATION_DATA,
+                ECHO_DATA,
                 **EMERGENCY_CONTACT_DATA,
                 key=self.key,
                 password=self.fritz.echo_password,

--- a/jdav_web/members/tests/utils.py
+++ b/jdav_web/members/tests/utils.py
@@ -29,6 +29,9 @@ REGISTRATION_DATA = {
     "email": settings.TEST_MAIL,
     "alternative_email": settings.TEST_MAIL,
 }
+# data for the echo (re-registration) form, which additionally requires the
+# DAV membership number
+ECHO_DATA = dict(REGISTRATION_DATA, dav_badge_no="114/00/245891")
 WAITER_DATA = {
     "prename": "Peter",
     "lastname": "Wulter",

--- a/jdav_web/members/views.py
+++ b/jdav_web/members/views.py
@@ -23,6 +23,12 @@ from .pdf import render_tex
 
 
 class MemberForm(RequiredFieldsMixin, ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for field in self.Meta.required:
+            self.fields[field].required = True
+
     class Meta:
         model = Member
         fields = [
@@ -42,10 +48,12 @@ class MemberForm(RequiredFieldsMixin, ModelForm):
             "prename": _("Prename of the member."),
             "lastname": _("Lastname of the member."),
             "phone_number": _("phone number of child or parent"),
+            "dav_badge_no": _("You can find this number on your DAV membership card."),
             "photos_may_be_taken": _(
                 "Are we allowed to take photos of you during activities? We use them for our public relations work."
             ),
         }
+        required = ["dav_badge_no"]
 
 
 class MemberRegistrationForm(RequiredFieldsMixin, ModelForm):


### PR DESCRIPTION
The DAV membership number was part of the echo (Rückmeldung) form, but
optional, so it stayed empty for most members. Make it a mandatory field
so members have to supply it when they echo back.

Add a help text pointing to the DAV membership card, mention the
requirement in the default echo mail text and in the user manual.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SFdyV23ams6VmbDaGUFLjT